### PR TITLE
外部ブラウザで URL を開く View を追加

### DIFF
--- a/Towards14/Towards14.xcodeproj/project.pbxproj
+++ b/Towards14/Towards14.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		C945BEC4254024BD00A6E173 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEC2254024BD00A6E173 /* Main.storyboard */; };
 		C945BEC6254024BF00A6E173 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C945BEC5254024BF00A6E173 /* Assets.xcassets */; };
 		C945BEC9254024BF00A6E173 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEC7254024BF00A6E173 /* LaunchScreen.storyboard */; };
+		C945BED42540628B00A6E173 /* CustomDefaultBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */; };
+		C945BED62540629E00A6E173 /* CustomDefaultBrowser.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +26,8 @@
 		C945BEC5254024BF00A6E173 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C945BEC8254024BF00A6E173 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C945BECA254024BF00A6E173 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDefaultBrowserViewController.swift; sourceTree = "<group>"; };
+		C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomDefaultBrowser.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,9 +82,19 @@
 		C945BED12540505500A6E173 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				C945BED22540626E00A6E173 /* CustomDefaultBrowser */,
 				C945BED02540484600A6E173 /* Main */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		C945BED22540626E00A6E173 /* CustomDefaultBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */,
+				C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */,
+			);
+			path = CustomDefaultBrowser;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -143,6 +157,7 @@
 			files = (
 				C945BEC9254024BF00A6E173 /* LaunchScreen.storyboard in Resources */,
 				C945BEC6254024BF00A6E173 /* Assets.xcassets in Resources */,
+				C945BED62540629E00A6E173 /* CustomDefaultBrowser.storyboard in Resources */,
 				C945BEC4254024BD00A6E173 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -156,6 +171,7 @@
 			files = (
 				C945BEC1254024BD00A6E173 /* MainViewController.swift in Sources */,
 				C945BEBD254024BD00A6E173 /* AppDelegate.swift in Sources */,
+				C945BED42540628B00A6E173 /* CustomDefaultBrowserViewController.swift in Sources */,
 				C945BEBF254024BD00A6E173 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Towards14/Towards14/View/CustomDefaultBrowser/CustomDefaultBrowser.storyboard
+++ b/Towards14/Towards14/View/CustomDefaultBrowser/CustomDefaultBrowser.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EeK-nm-HOZ">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Custom Default Browser View Controller-->
+        <scene sceneID="KHJ-tM-kIw">
+            <objects>
+                <viewController storyboardIdentifier="CustomDefaultBrowser" id="EeK-nm-HOZ" customClass="CustomDefaultBrowserViewController" customModule="Towards14" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="NeI-kl-Ofb">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SUY-Bc-D6u">
+                                <rect key="frame" x="153" y="427.5" width="108" height="41"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <state key="normal" title="Open URL"/>
+                                <connections>
+                                    <action selector="tapOpenURLButton:" destination="EeK-nm-HOZ" eventType="touchUpInside" id="LSM-Es-Z6B"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="SUY-Bc-D6u" firstAttribute="centerY" secondItem="NeI-kl-Ofb" secondAttribute="centerY" id="Nbg-L6-AB3"/>
+                            <constraint firstItem="SUY-Bc-D6u" firstAttribute="centerX" secondItem="NeI-kl-Ofb" secondAttribute="centerX" id="jnK-PK-3S0"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="GPz-ab-4G2"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Gjz-rw-wci" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="93" y="21"/>
+        </scene>
+    </scenes>
+</document>

--- a/Towards14/Towards14/View/CustomDefaultBrowser/CustomDefaultBrowserViewController.swift
+++ b/Towards14/Towards14/View/CustomDefaultBrowser/CustomDefaultBrowserViewController.swift
@@ -1,0 +1,30 @@
+//
+//  CustomDefaultBrowserViewController.swift
+//  Towards14
+//
+//  Created by 林 大地 on 2020/10/21.
+//  Copyright © 2020 林 大地. All rights reserved.
+//
+
+import UIKit
+
+class CustomDefaultBrowserViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    static func makeInstance() -> CustomDefaultBrowserViewController {
+        let storyboard = UIStoryboard(name: "CustomDefaultBrowser", bundle: nil)
+        return storyboard.instantiateInitialViewController() as! CustomDefaultBrowserViewController
+    }
+
+    @IBAction func tapOpenURLButton(_ sender: Any) {
+        let url = URL(string: "https://apple.com")!
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        } else {
+            print("Cannot Open URL")
+        }
+    }
+}

--- a/Towards14/Towards14/View/CustomDefaultBrowser/CustomDefaultBrowserViewController.swift
+++ b/Towards14/Towards14/View/CustomDefaultBrowser/CustomDefaultBrowserViewController.swift
@@ -24,7 +24,13 @@ class CustomDefaultBrowserViewController: UIViewController {
         if UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
         } else {
-            print("Cannot Open URL")
+            showAlert("Error", message: "Cannot open this URL.")
         }
+    }
+
+    private func showAlert(_ title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alertController, animated: true)
     }
 }

--- a/Towards14/Towards14/View/Main/MainViewController.swift
+++ b/Towards14/Towards14/View/Main/MainViewController.swift
@@ -46,6 +46,15 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
         return cell
     }
 
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
 
+        // 選択された cell によって遷移先を切り替える
+        switch indexPath.row {
+        case 0:
+            navigationController?.pushViewController(CustomDefaultBrowserViewController.makeInstance(), animated: true)
+        default:
+            return
+        }
+    }
 }
-

--- a/Towards14/Towards14/View/Main/MainViewController.swift
+++ b/Towards14/Towards14/View/Main/MainViewController.swift
@@ -50,6 +50,9 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
         tableView.deselectRow(at: indexPath, animated: true)
 
         // 選択された cell によって遷移先を切り替える
+        // NOTE: indexPath.row をハードコーディングによって分岐しているがあまり良い実装ではない
+        //       この記述によって意図しない ViewController へ遷移する等の問題が考えられる
+        //       対策としては enum を使う等がある。
         switch indexPath.row {
         case 0:
             navigationController?.pushViewController(CustomDefaultBrowserViewController.makeInstance(), animated: true)


### PR DESCRIPTION
## 概要

ボタンタップで URL を開く View を追加した

- MainView から Push で遷移
- 開く URL は暫定的に `https://apple.com` とした。
	- `canOpenURL` で URL をチェックし、開けない場合はアラートを表示するようにした。

## スクリーンショット

| 正常動作 | エラー時 |
| -- | -- |
| ![RocketSim Recording - iPhone 11 Pro - 2020-10-21 22 21 44](https://user-images.githubusercontent.com/31601805/96725502-e2e78c80-13eb-11eb-8dfd-a2afb7b64c9b.gif) | ![RocketSim Recording - iPhone 11 Pro - 2020-10-21 22 20 50](https://user-images.githubusercontent.com/31601805/96725321-bb90bf80-13eb-11eb-847d-3d91a88f4202.gif) |
