### PR TITLE
UIStackView が複数ある View を追加

### DIFF
--- a/Towards14/Towards14.xcodeproj/project.pbxproj
+++ b/Towards14/Towards14.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		C945BEC9254024BF00A6E173 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEC7254024BF00A6E173 /* LaunchScreen.storyboard */; };
 		C945BED42540628B00A6E173 /* CustomDefaultBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */; };
 		C945BED62540629E00A6E173 /* CustomDefaultBrowser.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */; };
+		C945BED925413F1300A6E173 /* StackViewBackground.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BED825413F1300A6E173 /* StackViewBackground.storyboard */; };
+		C945BEDB25413F2500A6E173 /* StackViewBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +30,8 @@
 		C945BECA254024BF00A6E173 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDefaultBrowserViewController.swift; sourceTree = "<group>"; };
 		C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomDefaultBrowser.storyboard; sourceTree = "<group>"; };
+		C945BED825413F1300A6E173 /* StackViewBackground.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = StackViewBackground.storyboard; sourceTree = "<group>"; };
+		C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackViewBackgroundViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +86,7 @@
 		C945BED12540505500A6E173 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				C945BED725413EFB00A6E173 /* StackViewBackground */,
 				C945BED22540626E00A6E173 /* CustomDefaultBrowser */,
 				C945BED02540484600A6E173 /* Main */,
 			);
@@ -91,10 +96,19 @@
 		C945BED22540626E00A6E173 /* CustomDefaultBrowser */ = {
 			isa = PBXGroup;
 			children = (
-				C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */,
 				C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */,
+				C945BED32540628B00A6E173 /* CustomDefaultBrowserViewController.swift */,
 			);
 			path = CustomDefaultBrowser;
+			sourceTree = "<group>";
+		};
+		C945BED725413EFB00A6E173 /* StackViewBackground */ = {
+			isa = PBXGroup;
+			children = (
+				C945BED825413F1300A6E173 /* StackViewBackground.storyboard */,
+				C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */,
+			);
+			path = StackViewBackground;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -155,6 +169,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C945BED925413F1300A6E173 /* StackViewBackground.storyboard in Resources */,
 				C945BEC9254024BF00A6E173 /* LaunchScreen.storyboard in Resources */,
 				C945BEC6254024BF00A6E173 /* Assets.xcassets in Resources */,
 				C945BED62540629E00A6E173 /* CustomDefaultBrowser.storyboard in Resources */,
@@ -170,6 +185,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C945BEC1254024BD00A6E173 /* MainViewController.swift in Sources */,
+				C945BEDB25413F2500A6E173 /* StackViewBackgroundViewController.swift in Sources */,
 				C945BEBD254024BD00A6E173 /* AppDelegate.swift in Sources */,
 				C945BED42540628B00A6E173 /* CustomDefaultBrowserViewController.swift in Sources */,
 				C945BEBF254024BD00A6E173 /* SceneDelegate.swift in Sources */,

--- a/Towards14/Towards14/View/Main/MainViewController.swift
+++ b/Towards14/Towards14/View/Main/MainViewController.swift
@@ -56,6 +56,8 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
         switch indexPath.row {
         case 0:
             navigationController?.pushViewController(CustomDefaultBrowserViewController.makeInstance(), animated: true)
+        case 1:
+            navigationController?.pushViewController(StackViewBackgroundViewController.makeInstance(), animated: true)
         default:
             return
         }

--- a/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
+++ b/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
@@ -14,7 +14,88 @@
                     <view key="view" contentMode="scaleToFill" id="wvx-dG-x4N">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="ONa-LF-ZyQ">
+                                <rect key="frame" x="50" y="244" width="314" height="318"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TOT-Pc-Ao3">
+                                        <rect key="frame" x="0.0" y="0.0" width="314" height="72.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1️⃣" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDM-vC-CWU">
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="72.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HStack 1 つ目" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVI-sN-GVS">
+                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="72.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemIndigoColor" red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="TVI-sN-GVS" firstAttribute="width" secondItem="eDM-vC-CWU" secondAttribute="width" multiplier="2" id="b6M-vQ-wf7"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lfk-tU-iVp">
+                                        <rect key="frame" x="0.0" y="122.5" width="314" height="73"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2️⃣" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hKS-y9-UlU">
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="73"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HStack 2 つ目" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oVe-KV-4Rq">
+                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="73"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="oVe-KV-4Rq" firstAttribute="width" secondItem="hKS-y9-UlU" secondAttribute="width" multiplier="2" id="q77-V8-teC"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Y6Z-98-NYe">
+                                        <rect key="frame" x="0.0" y="245.5" width="314" height="72.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3️⃣" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ea1-fq-fpN">
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="72.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HStack 3 つ目" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WAU-go-nFW">
+                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="72.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="WAU-go-nFW" firstAttribute="width" secondItem="ea1-fq-fpN" secondAttribute="width" multiplier="2" id="uJm-ee-1zZ"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstItem="lfk-tU-iVp" firstAttribute="height" secondItem="TOT-Pc-Ao3" secondAttribute="height" id="K8n-Dn-xbB"/>
+                                    <constraint firstItem="Y6Z-98-NYe" firstAttribute="height" secondItem="TOT-Pc-Ao3" secondAttribute="height" id="sjt-O2-Cbh"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="ONa-LF-ZyQ" firstAttribute="leading" secondItem="om1-dJ-t9V" secondAttribute="leading" constant="50" id="Lex-6K-JBz"/>
+                            <constraint firstItem="om1-dJ-t9V" firstAttribute="bottom" secondItem="ONa-LF-ZyQ" secondAttribute="bottom" constant="300" id="MZn-Q1-G70"/>
+                            <constraint firstItem="ONa-LF-ZyQ" firstAttribute="top" secondItem="om1-dJ-t9V" secondAttribute="top" constant="200" id="RBC-Nw-7C2"/>
+                            <constraint firstItem="om1-dJ-t9V" firstAttribute="trailing" secondItem="ONa-LF-ZyQ" secondAttribute="trailing" constant="50" id="cRk-BV-Acu"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="om1-dJ-t9V"/>
                     </view>
                 </viewController>

--- a/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
+++ b/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
@@ -15,20 +15,20 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="ONa-LF-ZyQ">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ONa-LF-ZyQ">
                                 <rect key="frame" x="50" y="244" width="314" height="318"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TOT-Pc-Ao3">
-                                        <rect key="frame" x="0.0" y="0.0" width="314" height="72.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="314" height="92.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1️⃣" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDM-vC-CWU">
-                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="72.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="92.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HStack 1 つ目" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVI-sN-GVS">
-                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="72.5"/>
+                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="92.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -40,16 +40,16 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lfk-tU-iVp">
-                                        <rect key="frame" x="0.0" y="122.5" width="314" height="73"/>
+                                        <rect key="frame" x="0.0" y="112.5" width="314" height="93"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2️⃣" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hKS-y9-UlU">
-                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="73"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="93"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HStack 2 つ目" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oVe-KV-4Rq">
-                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="73"/>
+                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="93"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -61,16 +61,16 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Y6Z-98-NYe">
-                                        <rect key="frame" x="0.0" y="245.5" width="314" height="72.5"/>
+                                        <rect key="frame" x="0.0" y="225.5" width="314" height="92.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3️⃣" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ea1-fq-fpN">
-                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="72.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="104.5" height="92.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HStack 3 つ目" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WAU-go-nFW">
-                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="72.5"/>
+                                                <rect key="frame" x="104.5" y="0.0" width="209.5" height="92.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
+++ b/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tKd-in-68A">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Stack View Background View Controller-->
+        <scene sceneID="mes-oi-byP">
+            <objects>
+                <viewController storyboardIdentifier="StackViewBackground" id="tKd-in-68A" customClass="StackViewBackgroundViewController" customModule="Towards14" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="wvx-dG-x4N">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="om1-dJ-t9V"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uVJ-I1-fmk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="49" y="21"/>
+        </scene>
+    </scenes>
+</document>

--- a/Towards14/Towards14/View/StackViewBackground/StackViewBackgroundViewController.swift
+++ b/Towards14/Towards14/View/StackViewBackground/StackViewBackgroundViewController.swift
@@ -1,0 +1,21 @@
+//
+//  StackViewBackgroundViewController.swift
+//  Towards14
+//
+//  Created by 林 大地 on 2020/10/22.
+//  Copyright © 2020 林 大地. All rights reserved.
+//
+
+import UIKit
+
+class StackViewBackgroundViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    static func makeInstance() -> StackViewBackgroundViewController {
+        let storyboard = UIStoryboard(name: "StackViewBackground", bundle: nil)
+        return storyboard.instantiateInitialViewController() as! StackViewBackgroundViewController
+    }
+}


### PR DESCRIPTION
## 概要

- `UIStackView` が複数存在する View を追加した
	- VC 直下に VStack を 1 つ配置
		- VStack 配下に HStack を 3 つ配置
			- 各 HStack に `UILabel` を 2 つ配置
	- という構造になっている
- 当該 View への遷移は Push 遷移としている

## スクリーンショット

<img width=300 src="https://user-images.githubusercontent.com/31601805/96846600-175f5500-148d-11eb-8c4e-47edeac5b882.gif">
