### PR TITLE
デフォルトブラウザを変更した際に `canOpenURL(_:)` が false になる問題を修正

### DIFF
--- a/Towards14/Towards14/Info.plist
+++ b/Towards14/Towards14/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>http</string>
+		<string>https</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Towards14/Towards14/Info.plist
+++ b/Towards14/Towards14/Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>http</string>
 		<string>https</string>
+		<string>mailto</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>


### PR DESCRIPTION
## 問題

- iOS 14 端末ではデフォルトブラウザを変更可能になっている。
- その際に `canOpenURL(_:)` が false になってしまう問題がある。
- Fix #3 

## 対策

- `Info.plist` の `LSApplicationQueriesSchemes` に `http`, `https` を追加した。
	- Apple 公式に記述がある。
		- [Preparing Your App to be the Default Browser or Email Client | Apple Developer Documentation](https://developer.apple.com/documentation/xcode/allowing_apps_and_websites_to_link_to_your_content/preparing_your_app_to_be_the_default_browser_or_email_client)
- 同様にメーラーも変更可能なため、 `mailto` も追加した。

## 参考文献
- [【iOS14】デフォルトブラウザを変更した時にcanOpenURLがfalseになる問題 - Qiita](https://qiita.com/toto_kit/items/757dfe0a9fddb28eeff5)