### PR TITLE
ボタンタップで 3 階層 Push 遷移する View を追加

### DIFF
--- a/Towards14/Towards14.xcodeproj/project.pbxproj
+++ b/Towards14/Towards14.xcodeproj/project.pbxproj
@@ -19,6 +19,12 @@
 		C945BEDB25413F2500A6E173 /* StackViewBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */; };
 		C945BEE325469CB800A6E173 /* PushBackButtonLongPress.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEE225469CB800A6E173 /* PushBackButtonLongPress.storyboard */; };
 		C945BEE525469CC700A6E173 /* PushBackButtonLongPressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEE425469CC700A6E173 /* PushBackButtonLongPressViewController.swift */; };
+		C945BEE92547E19D00A6E173 /* ChildrenOneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEE82547E19D00A6E173 /* ChildrenOneViewController.swift */; };
+		C945BEEB2547E1AB00A6E173 /* ChildrenOne.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEEA2547E1AB00A6E173 /* ChildrenOne.storyboard */; };
+		C945BEED2547E1B500A6E173 /* ChildrenTwo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEEC2547E1B500A6E173 /* ChildrenTwo.storyboard */; };
+		C945BEEF2547E1C000A6E173 /* ChildrenTwoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEEE2547E1C000A6E173 /* ChildrenTwoViewController.swift */; };
+		C945BEF12547E1D000A6E173 /* ChildrenThree.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEF02547E1D000A6E173 /* ChildrenThree.storyboard */; };
+		C945BEF32547E1DA00A6E173 /* ChildrenThreeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEF22547E1DA00A6E173 /* ChildrenThreeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +42,12 @@
 		C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackViewBackgroundViewController.swift; sourceTree = "<group>"; };
 		C945BEE225469CB800A6E173 /* PushBackButtonLongPress.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PushBackButtonLongPress.storyboard; sourceTree = "<group>"; };
 		C945BEE425469CC700A6E173 /* PushBackButtonLongPressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushBackButtonLongPressViewController.swift; sourceTree = "<group>"; };
+		C945BEE82547E19D00A6E173 /* ChildrenOneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildrenOneViewController.swift; sourceTree = "<group>"; };
+		C945BEEA2547E1AB00A6E173 /* ChildrenOne.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ChildrenOne.storyboard; sourceTree = "<group>"; };
+		C945BEEC2547E1B500A6E173 /* ChildrenTwo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ChildrenTwo.storyboard; sourceTree = "<group>"; };
+		C945BEEE2547E1C000A6E173 /* ChildrenTwoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildrenTwoViewController.swift; sourceTree = "<group>"; };
+		C945BEF02547E1D000A6E173 /* ChildrenThree.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ChildrenThree.storyboard; sourceTree = "<group>"; };
+		C945BEF22547E1DA00A6E173 /* ChildrenThreeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildrenThreeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,10 +131,24 @@
 		C945BEE125469C8B00A6E173 /* PushBackButtonLongPress */ = {
 			isa = PBXGroup;
 			children = (
+				C945BEE62547E0AC00A6E173 /* Children */,
 				C945BEE225469CB800A6E173 /* PushBackButtonLongPress.storyboard */,
 				C945BEE425469CC700A6E173 /* PushBackButtonLongPressViewController.swift */,
 			);
 			path = PushBackButtonLongPress;
+			sourceTree = "<group>";
+		};
+		C945BEE62547E0AC00A6E173 /* Children */ = {
+			isa = PBXGroup;
+			children = (
+				C945BEEA2547E1AB00A6E173 /* ChildrenOne.storyboard */,
+				C945BEE82547E19D00A6E173 /* ChildrenOneViewController.swift */,
+				C945BEEC2547E1B500A6E173 /* ChildrenTwo.storyboard */,
+				C945BEEE2547E1C000A6E173 /* ChildrenTwoViewController.swift */,
+				C945BEF02547E1D000A6E173 /* ChildrenThree.storyboard */,
+				C945BEF22547E1DA00A6E173 /* ChildrenThreeViewController.swift */,
+			);
+			path = Children;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -183,6 +209,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C945BEF12547E1D000A6E173 /* ChildrenThree.storyboard in Resources */,
+				C945BEED2547E1B500A6E173 /* ChildrenTwo.storyboard in Resources */,
+				C945BEEB2547E1AB00A6E173 /* ChildrenOne.storyboard in Resources */,
 				C945BED925413F1300A6E173 /* StackViewBackground.storyboard in Resources */,
 				C945BEC9254024BF00A6E173 /* LaunchScreen.storyboard in Resources */,
 				C945BEC6254024BF00A6E173 /* Assets.xcassets in Resources */,
@@ -202,6 +231,9 @@
 				C945BEC1254024BD00A6E173 /* MainViewController.swift in Sources */,
 				C945BEDB25413F2500A6E173 /* StackViewBackgroundViewController.swift in Sources */,
 				C945BEBD254024BD00A6E173 /* AppDelegate.swift in Sources */,
+				C945BEF32547E1DA00A6E173 /* ChildrenThreeViewController.swift in Sources */,
+				C945BEE92547E19D00A6E173 /* ChildrenOneViewController.swift in Sources */,
+				C945BEEF2547E1C000A6E173 /* ChildrenTwoViewController.swift in Sources */,
 				C945BED42540628B00A6E173 /* CustomDefaultBrowserViewController.swift in Sources */,
 				C945BEBF254024BD00A6E173 /* SceneDelegate.swift in Sources */,
 				C945BEE525469CC700A6E173 /* PushBackButtonLongPressViewController.swift in Sources */,

--- a/Towards14/Towards14.xcodeproj/project.pbxproj
+++ b/Towards14/Towards14.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		C945BED62540629E00A6E173 /* CustomDefaultBrowser.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */; };
 		C945BED925413F1300A6E173 /* StackViewBackground.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BED825413F1300A6E173 /* StackViewBackground.storyboard */; };
 		C945BEDB25413F2500A6E173 /* StackViewBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */; };
+		C945BEE325469CB800A6E173 /* PushBackButtonLongPress.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C945BEE225469CB800A6E173 /* PushBackButtonLongPress.storyboard */; };
+		C945BEE525469CC700A6E173 /* PushBackButtonLongPressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C945BEE425469CC700A6E173 /* PushBackButtonLongPressViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +34,8 @@
 		C945BED52540629E00A6E173 /* CustomDefaultBrowser.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomDefaultBrowser.storyboard; sourceTree = "<group>"; };
 		C945BED825413F1300A6E173 /* StackViewBackground.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = StackViewBackground.storyboard; sourceTree = "<group>"; };
 		C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackViewBackgroundViewController.swift; sourceTree = "<group>"; };
+		C945BEE225469CB800A6E173 /* PushBackButtonLongPress.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PushBackButtonLongPress.storyboard; sourceTree = "<group>"; };
+		C945BEE425469CC700A6E173 /* PushBackButtonLongPressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushBackButtonLongPressViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +90,7 @@
 		C945BED12540505500A6E173 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				C945BEE125469C8B00A6E173 /* PushBackButtonLongPress */,
 				C945BED725413EFB00A6E173 /* StackViewBackground */,
 				C945BED22540626E00A6E173 /* CustomDefaultBrowser */,
 				C945BED02540484600A6E173 /* Main */,
@@ -109,6 +114,15 @@
 				C945BEDA25413F2500A6E173 /* StackViewBackgroundViewController.swift */,
 			);
 			path = StackViewBackground;
+			sourceTree = "<group>";
+		};
+		C945BEE125469C8B00A6E173 /* PushBackButtonLongPress */ = {
+			isa = PBXGroup;
+			children = (
+				C945BEE225469CB800A6E173 /* PushBackButtonLongPress.storyboard */,
+				C945BEE425469CC700A6E173 /* PushBackButtonLongPressViewController.swift */,
+			);
+			path = PushBackButtonLongPress;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -174,6 +188,7 @@
 				C945BEC6254024BF00A6E173 /* Assets.xcassets in Resources */,
 				C945BED62540629E00A6E173 /* CustomDefaultBrowser.storyboard in Resources */,
 				C945BEC4254024BD00A6E173 /* Main.storyboard in Resources */,
+				C945BEE325469CB800A6E173 /* PushBackButtonLongPress.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -189,6 +204,7 @@
 				C945BEBD254024BD00A6E173 /* AppDelegate.swift in Sources */,
 				C945BED42540628B00A6E173 /* CustomDefaultBrowserViewController.swift in Sources */,
 				C945BEBF254024BD00A6E173 /* SceneDelegate.swift in Sources */,
+				C945BEE525469CC700A6E173 /* PushBackButtonLongPressViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Towards14/Towards14/View/Main/MainViewController.swift
+++ b/Towards14/Towards14/View/Main/MainViewController.swift
@@ -13,6 +13,7 @@ class MainViewController: UIViewController {
     private let appTitles = [
         "CustomDefaultBrowser",
         "UIStackViewBackgroundColor",
+        "PushBackButtonLongPress",
     ]
 
     // MARK: - IBOutlet
@@ -58,6 +59,8 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
             navigationController?.pushViewController(CustomDefaultBrowserViewController.makeInstance(), animated: true)
         case 1:
             navigationController?.pushViewController(StackViewBackgroundViewController.makeInstance(), animated: true)
+        case 2:
+            navigationController?.pushViewController(PushBackButtonLongPressViewController.makeInstance(), animated: true)
         default:
             return
         }

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOne.storyboard
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOne.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QzK-bf-agi">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Children One View Controller-->
+        <scene sceneID="6bc-Q9-1hc">
+            <objects>
+                <viewController id="QzK-bf-agi" customClass="ChildrenOneViewController" customModule="Towards14" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Qb4-VW-DJM">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WNr-VW-Grc">
+                                <rect key="frame" x="161" y="433" width="92" height="30"/>
+                                <state key="normal" title="画面遷移する"/>
+                                <connections>
+                                    <action selector="tapButton:" destination="QzK-bf-agi" eventType="touchUpInside" id="Gm8-1I-MZH"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="01" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5DO-lG-hzO">
+                                <rect key="frame" x="183" y="353" width="48.5" height="40"/>
+                                <fontDescription key="fontDescription" name="Courier" family="Courier" pointSize="40"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="5DO-lG-hzO" firstAttribute="centerX" secondItem="Qb4-VW-DJM" secondAttribute="centerX" id="1G6-fX-frX"/>
+                            <constraint firstItem="WNr-VW-Grc" firstAttribute="centerY" secondItem="Qb4-VW-DJM" secondAttribute="centerY" id="5IP-3u-OLI"/>
+                            <constraint firstItem="WNr-VW-Grc" firstAttribute="top" secondItem="5DO-lG-hzO" secondAttribute="bottom" constant="40" id="Zmc-Zw-kou"/>
+                            <constraint firstItem="WNr-VW-Grc" firstAttribute="centerX" secondItem="Qb4-VW-DJM" secondAttribute="centerX" id="z7J-Ex-hGW"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="L1Y-81-xqd"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fvg-bz-Rd5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="138"/>
+        </scene>
+    </scenes>
+</document>

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ChildrenOneViewController.swift
+//  Towards14
+//
+//  Created by 林 大地 on 2020/10/27.
+//  Copyright © 2020 林 大地. All rights reserved.
+//
+
+import UIKit
+
+class ChildrenOneViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    static func makeInstance() -> ChildrenOneViewController {
+        let storyboard = UIStoryboard(name: "ChildrenOne", bundle: nil)
+        return storyboard.instantiateInitialViewController() as! ChildrenOneViewController
+    }
+
+    @IBAction func tapButton(_ sender: Any) {
+        navigationController?.pushViewController(ChildrenTwoViewController.makeInstance(), animated: true)
+    }
+}

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThree.storyboard
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThree.storyboard
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M8e-N6-NSu">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Children Three View Controller-->
+        <scene sceneID="K73-O5-sXH">
+            <objects>
+                <viewController id="M8e-N6-NSu" customClass="ChildrenThreeViewController" customModule="Towards14" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Zze-dX-baf">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="03" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WOM-Zz-sNx">
+                                <rect key="frame" x="182.5" y="357.5" width="49" height="40"/>
+                                <fontDescription key="fontDescription" name="Courier" family="Courier" pointSize="40"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="これ以上は画面遷移しないよ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vhA-2H-n3Q">
+                                <rect key="frame" x="94" y="437.5" width="226" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="vhA-2H-n3Q" firstAttribute="centerY" secondItem="Zze-dX-baf" secondAttribute="centerY" id="2V6-Wi-pdP"/>
+                            <constraint firstItem="vhA-2H-n3Q" firstAttribute="centerX" secondItem="Zze-dX-baf" secondAttribute="centerX" id="qg5-pl-4cl"/>
+                            <constraint firstItem="WOM-Zz-sNx" firstAttribute="centerX" secondItem="Zze-dX-baf" secondAttribute="centerX" id="rOY-fD-wL9"/>
+                            <constraint firstItem="vhA-2H-n3Q" firstAttribute="top" secondItem="WOM-Zz-sNx" secondAttribute="bottom" constant="40" id="t1M-Cq-KQY"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="1zn-vB-aKG"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Lcx-GT-I1Q" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="138"/>
+        </scene>
+    </scenes>
+</document>

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
@@ -1,0 +1,21 @@
+//
+//  ChildrenThreeViewController.swift
+//  Towards14
+//
+//  Created by 林 大地 on 2020/10/27.
+//  Copyright © 2020 林 大地. All rights reserved.
+//
+
+import UIKit
+
+class ChildrenThreeViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    static func makeInstance() -> ChildrenThreeViewController {
+        let storyboard = UIStoryboard(name: "ChildrenThree", bundle: nil)
+        return storyboard.instantiateInitialViewController() as! ChildrenThreeViewController
+    }
+}

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwo.storyboard
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwo.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="J03-Aj-Gz8">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Children Two View Controller-->
+        <scene sceneID="Lg6-Qz-06k">
+            <objects>
+                <viewController id="J03-Aj-Gz8" customClass="ChildrenTwoViewController" customModule="Towards14" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="SLa-pD-Jdc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LvU-rN-Tiu">
+                                <rect key="frame" x="161" y="433" width="92" height="30"/>
+                                <state key="normal" title="画面遷移する"/>
+                                <connections>
+                                    <action selector="tapButton:" destination="J03-Aj-Gz8" eventType="touchUpInside" id="2IN-4I-ql8"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="02" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B9u-Si-6SH">
+                                <rect key="frame" x="182.5" y="353" width="49" height="40"/>
+                                <fontDescription key="fontDescription" name="Courier" family="Courier" pointSize="40"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="LvU-rN-Tiu" firstAttribute="centerY" secondItem="SLa-pD-Jdc" secondAttribute="centerY" id="K6s-hD-Off"/>
+                            <constraint firstItem="LvU-rN-Tiu" firstAttribute="centerX" secondItem="SLa-pD-Jdc" secondAttribute="centerX" id="Sjo-UP-bcA"/>
+                            <constraint firstItem="B9u-Si-6SH" firstAttribute="centerX" secondItem="SLa-pD-Jdc" secondAttribute="centerX" id="ZMf-Z9-ZoW"/>
+                            <constraint firstItem="LvU-rN-Tiu" firstAttribute="top" secondItem="B9u-Si-6SH" secondAttribute="bottom" constant="40" id="rJU-sj-Ks1"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="UOA-MB-vof"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3pc-PV-pZU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="138"/>
+        </scene>
+    </scenes>
+</document>

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ChildrenTwoViewController.swift
+//  Towards14
+//
+//  Created by 林 大地 on 2020/10/27.
+//  Copyright © 2020 林 大地. All rights reserved.
+//
+
+import UIKit
+
+class ChildrenTwoViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    static func makeInstance() -> ChildrenTwoViewController {
+        let storyboard = UIStoryboard(name: "ChildrenTwo", bundle: nil)
+        return storyboard.instantiateInitialViewController() as! ChildrenTwoViewController
+    }
+
+    @IBAction func tapButton(_ sender: Any) {
+        navigationController?.pushViewController(ChildrenThreeViewController.makeInstance(), animated: true)
+    }
+}

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPress.storyboard
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPress.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Iyp-GP-EWZ">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Push Back Button Long Press View Controller-->
+        <scene sceneID="eQl-BN-GjU">
+            <objects>
+                <viewController id="Iyp-GP-EWZ" customClass="PushBackButtonLongPressViewController" customModule="Towards14" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Eph-bG-nlB">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="2AI-Hz-ydQ"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0zr-GW-Lzq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="137"/>
+        </scene>
+    </scenes>
+</document>

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPress.storyboard
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPress.storyboard
@@ -14,7 +14,28 @@
                     <view key="view" contentMode="scaleToFill" id="Eph-bG-nlB">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c1C-ZJ-pQR">
+                                <rect key="frame" x="161" y="433" width="92" height="30"/>
+                                <state key="normal" title="画面遷移する"/>
+                                <connections>
+                                    <action selector="tapButton:" destination="Iyp-GP-EWZ" eventType="touchUpInside" id="j3R-cO-UGB"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wSb-Ax-xfc">
+                                <rect key="frame" x="182.5" y="353" width="49" height="40"/>
+                                <fontDescription key="fontDescription" name="Courier" family="Courier" pointSize="40"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="c1C-ZJ-pQR" firstAttribute="centerY" secondItem="Eph-bG-nlB" secondAttribute="centerY" id="Ol8-G9-b9U"/>
+                            <constraint firstItem="c1C-ZJ-pQR" firstAttribute="centerX" secondItem="Eph-bG-nlB" secondAttribute="centerX" id="P7E-6M-mEk"/>
+                            <constraint firstItem="c1C-ZJ-pQR" firstAttribute="top" secondItem="wSb-Ax-xfc" secondAttribute="bottom" constant="40" id="Q24-y5-i1d"/>
+                            <constraint firstItem="wSb-Ax-xfc" firstAttribute="centerX" secondItem="Eph-bG-nlB" secondAttribute="centerX" id="UkR-ds-Jb3"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="2AI-Hz-ydQ"/>
                     </view>
                 </viewController>

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
@@ -1,0 +1,21 @@
+//
+//  PushBackButtonLongPressViewController.swift
+//  Towards14
+//
+//  Created by 林 大地 on 2020/10/26.
+//  Copyright © 2020 林 大地. All rights reserved.
+//
+
+import UIKit
+
+class PushBackButtonLongPressViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    static func makeInstance() -> PushBackButtonLongPressViewController {
+        let storyboard = UIStoryboard(name: "PushBackButtonLongPress", bundle: nil)
+        return storyboard.instantiateInitialViewController() as! PushBackButtonLongPressViewController
+    }
+}

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
@@ -18,4 +18,8 @@ class PushBackButtonLongPressViewController: UIViewController {
         let storyboard = UIStoryboard(name: "PushBackButtonLongPress", bundle: nil)
         return storyboard.instantiateInitialViewController() as! PushBackButtonLongPressViewController
     }
+
+    @IBAction func tapButton(_ sender: Any) {
+        navigationController?.pushViewController(ChildrenOneViewController.makeInstance(), animated: true)
+    }
 }


### PR DESCRIPTION
## 概要

- ボタンをタップすると Push 遷移する View を追加した (`PushBackButtonLongPressViewController`)
	- その子 VC も同様に Push 遷移し、 3 階層まで潜れる。
- 画面遷移図:

```plain
RootViewController
  └ PushBackButtonLongPressViewController
    └ ChildrenOneViewController
      └ ChildrenTwoViewController
        └ ChildrenThreeViewController

```

## スクリーンショット

| PushBackButtonLongPressVC | ChildrenOneVC | ChildrenTwoVC | ChildrenThreeVC |
| -- | -- | -- | -- |
| ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-27 at 22 53 17](https://user-images.githubusercontent.com/31601805/97311126-5f281700-18a7-11eb-88da-d55e13d0afe0.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-27 at 22 53 45](https://user-images.githubusercontent.com/31601805/97311125-5e8f8080-18a7-11eb-9189-c481000c463a.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-27 at 22 53 54](https://user-images.githubusercontent.com/31601805/97311116-5d5e5380-18a7-11eb-8970-253bd659996b.png) | ![simulator_screenshot_E4DB92ED-3A17-4A35-9921-5896893E157E](https://user-images.githubusercontent.com/31601805/97311321-95659680-18a7-11eb-8098-648ca59b59ea.png) |

