### PR TITLE
backButtonTitle のデザイン調整 (空文字にした)

### DIFF
--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
@@ -12,6 +12,7 @@ class ChildrenOneViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.backButtonTitle = ""
     }
     
     static func makeInstance() -> ChildrenOneViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
@@ -12,6 +12,7 @@ class ChildrenThreeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.backButtonTitle = ""
     }
 
     static func makeInstance() -> ChildrenThreeViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
@@ -12,6 +12,7 @@ class ChildrenTwoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.backButtonTitle = ""
     }
     
     static func makeInstance() -> ChildrenTwoViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
@@ -12,6 +12,7 @@ class PushBackButtonLongPressViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.backButtonTitle = ""
     }
 
     static func makeInstance() -> PushBackButtonLongPressViewController {


### PR DESCRIPTION
## 概要

- `PushBackButtonLongPressViewController` およびそれから遷移する VC の `navigationItem.backButtonTitle` を空文字にした
- 今までは `Back` となっていたが、デザイン的に空文字にした。

## スクリーンショット

|修正前|修正後|
|--|--|
|![RocketSim Recording - iPhone 11 Pro - 2020-10-28 10 07 53](https://user-images.githubusercontent.com/31601805/97378414-a5ac5e80-1905-11eb-95e4-fac935328156.gif)|![RocketSim Recording - iPhone 11 Pro - 2020-10-28 10 08 43](https://user-images.githubusercontent.com/31601805/97378423-a9d87c00-1905-11eb-8d76-38d72c94293b.gif)|

## 備考

backButtonTitle を変更するには、

1. `self.title`
2. `self.navigatonItem.backButtonTitle`

のいずれかを変更すればよい。
しかし、両者には優先度があり、 `navigationItem.backButtonTitle` が優先された。

実験してみたので、結果を表にまとめる。

|`self.title` | `self.navigatonItem.backButtonTitle` | 結果: `backButtonTitle` | 結果: スクリーンショット |
| :-- | :-- | :-- | -- |
| `nil` | `nil` | "Back" | ![simulator_screenshot_3C6E55B2-AC50-4BB9-A711-F1E2B](https://user-images.githubusercontent.com/31601805/97379136-6e3eb180-1907-11eb-8988-03ac4f62bfb5.png)|
| `nil` | `""` (空文字) | `""` (空文字) |![simulator_screenshot_32EA0B14-FCB6-4C75-84BD-85CA8](https://user-images.githubusercontent.com/31601805/97379139-70087500-1907-11eb-836b-466c9c90eb6a.png)|
| `"0 番目の View"` | `nil` | "0 番目の View" |![simulator_screenshot_FA6CA846-DFDB-4C19-9502-C2957](https://user-images.githubusercontent.com/31601805/97379141-70087500-1907-11eb-9fc4-3b3783125663.png)|
| `"0 番目の View"` | `""` (空文字) | `""` (空文字) |![simulator_screenshot_80D77599-D703-4F00-9157-D7474](https://user-images.githubusercontent.com/31601805/97379142-7139a200-1907-11eb-82cc-ae50ca454292.png)|