### PR TITLE
iOS 14 端末で UIStackView の backgroundColor が見えるようになったので不要な背景色を削除

### DIFF
--- a/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
+++ b/Towards14/Towards14/View/StackViewBackground/StackViewBackground.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tKd-in-68A">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tKd-in-68A">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -34,7 +36,6 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemIndigoColor" red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstItem="TVI-sN-GVS" firstAttribute="width" secondItem="eDM-vC-CWU" secondAttribute="width" multiplier="2" id="b6M-vQ-wf7"/>
                                         </constraints>
@@ -55,7 +56,6 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstItem="oVe-KV-4Rq" firstAttribute="width" secondItem="hKS-y9-UlU" secondAttribute="width" multiplier="2" id="q77-V8-teC"/>
                                         </constraints>
@@ -76,27 +76,25 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstItem="WAU-go-nFW" firstAttribute="width" secondItem="ea1-fq-fpN" secondAttribute="width" multiplier="2" id="uJm-ee-1zZ"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="lfk-tU-iVp" firstAttribute="height" secondItem="TOT-Pc-Ao3" secondAttribute="height" id="K8n-Dn-xbB"/>
                                     <constraint firstItem="Y6Z-98-NYe" firstAttribute="height" secondItem="TOT-Pc-Ao3" secondAttribute="height" id="sjt-O2-Cbh"/>
                                 </constraints>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="om1-dJ-t9V"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ONa-LF-ZyQ" firstAttribute="leading" secondItem="om1-dJ-t9V" secondAttribute="leading" constant="50" id="Lex-6K-JBz"/>
                             <constraint firstItem="om1-dJ-t9V" firstAttribute="bottom" secondItem="ONa-LF-ZyQ" secondAttribute="bottom" constant="300" id="MZn-Q1-G70"/>
                             <constraint firstItem="ONa-LF-ZyQ" firstAttribute="top" secondItem="om1-dJ-t9V" secondAttribute="top" constant="200" id="RBC-Nw-7C2"/>
                             <constraint firstItem="om1-dJ-t9V" firstAttribute="trailing" secondItem="ONa-LF-ZyQ" secondAttribute="trailing" constant="50" id="cRk-BV-Acu"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="om1-dJ-t9V"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uVJ-I1-fmk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -104,4 +102,9 @@
             <point key="canvasLocation" x="49" y="21"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
## 問題
- iOS 13 以内では見えなかった UIStackView の backgroundColor が iOS 14 で見えるようになった
- StackView を使用している View を Xcode 12 でビルドしたところ、不要な背景色を付与していた部分があったので削除した。
- Close #5 

## 解決法
- backgroundColor を InterfaceBuilder によって Default に設定した

## スクリーンショット

|修正前|修正後|
|--|--|
|<img width=300 src="https://user-images.githubusercontent.com/31601805/96848962-03692280-1490-11eb-8e1f-1b37845fdab8.png">|<img width=300 src="https://user-images.githubusercontent.com/31601805/97792262-72c4dc00-1c1f-11eb-93e3-1aef21c35858.png">|