### PR TITLE
iOS 14 で backButton 長押しでタイトルが付くようになったのに対応

### DIFF
--- a/Towards14/Towards14/AppDelegate.swift
+++ b/Towards14/Towards14/AppDelegate.swift
@@ -15,6 +15,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+
+        // NavigationBar の backButtonTitle を消す
+        // NOTE: 消したい VC の self.title, self.navigationItem.backButtonTitle = ""
+        //       としても実現できるが、 iOS 14 では backButton 長押しでタイトルが付くようになったので、それに対応している。
+        //       具体的には、 UIColor.clear を当てることでタイトルを透過させている。
+        // SEE: https://sarunw.com/posts/what-should-you-know-about-navigation-history-stack-in-ios14/
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+
+        appearance.backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear]
+
+        UINavigationBar.appearance().standardAppearance = appearance
+        UINavigationBar.appearance().compactAppearance = appearance
+
         return true
     }
 

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
@@ -12,7 +12,7 @@ class ChildrenOneViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "1番目", style: .plain, target: nil, action: nil)
     }
     
     static func makeInstance() -> ChildrenOneViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
@@ -12,8 +12,7 @@ class ChildrenThreeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title:
-            "3番目", style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "3番目", style: .plain, target: nil, action: nil)
     }
 
     static func makeInstance() -> ChildrenThreeViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
@@ -12,7 +12,8 @@ class ChildrenThreeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title:
+            "3番目", style: .plain, target: nil, action: nil)
     }
 
     static func makeInstance() -> ChildrenThreeViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
@@ -12,7 +12,7 @@ class ChildrenTwoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "2番目", style: .plain, target: nil, action: nil)
     }
     
     static func makeInstance() -> ChildrenTwoViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
@@ -12,7 +12,7 @@ class PushBackButtonLongPressViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "0番目", style: .plain, target: nil, action: nil)
     }
 
     static func makeInstance() -> PushBackButtonLongPressViewController {


### PR DESCRIPTION
## 問題
- iOS 14 から NavigationBar の backButton 長押しでタイトルのリストが出るようになった。
- 本アプリではデザイン的に backButton のタイトルを空文字に設定しており、そのままでは長押しした際に何も表示されず、 UX を損ねていた。

## 対策
- backButtonTitle は付けるが、デザイン上は透過させるようにした。
- `application(_ application:, didFinishLaunchingWithOptions:)` にそのような処理を追加した。

## スクリーンショット

|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;OS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 修正前 | 修正後 |
|--|--|--|
|13|![image](https://user-images.githubusercontent.com/31601805/97805338-d4755c80-1c98-11eb-9501-bc43a2a3a267.png)|![image](https://user-images.githubusercontent.com/31601805/97805284-82343b80-1c98-11eb-9c9a-50645838cd3e.png)|
|14|![image](https://user-images.githubusercontent.com/31601805/97805322-bb6cab80-1c98-11eb-9d7b-6de713612c81.png)|![image](https://user-images.githubusercontent.com/31601805/97805278-78123d00-1c98-11eb-9e74-bebca9bf5b41.png)|
|14 (長押し) |![image](https://user-images.githubusercontent.com/31601805/97805331-c7586d80-1c98-11eb-89a0-748bfb903b39.png)|![image](https://user-images.githubusercontent.com/31601805/97805288-88c2b300-1c98-11eb-885d-208275db6848.png)|

## 参考
- [What should you know about a navigation history stack in iOS 14 \| Sarun](https://sarunw.com/posts/what-should-you-know-about-navigation-history-stack-in-ios14/)