### PR TITLE
バックボタンタイトル・履歴メニュータイトルの制御を navigationItem.backButtonDisplayMode に変更

### DIFF
--- a/Towards14/Towards14/AppDelegate.swift
+++ b/Towards14/Towards14/AppDelegate.swift
@@ -15,20 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-
-        // NavigationBar の backButtonTitle を消す
-        // NOTE: 消したい VC の self.title, self.navigationItem.backButtonTitle = ""
-        //       としても実現できるが、 iOS 14 では backButton 長押しでタイトルが付くようになったので、それに対応している。
-        //       具体的には、 UIColor.clear を当てることでタイトルを透過させている。
-        // SEE: https://sarunw.com/posts/what-should-you-know-about-navigation-history-stack-in-ios14/
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithDefaultBackground()
-
-        appearance.backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear]
-
-        UINavigationBar.appearance().standardAppearance = appearance
-        UINavigationBar.appearance().compactAppearance = appearance
-
         return true
     }
 

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenOneViewController.swift
@@ -12,7 +12,17 @@ class ChildrenOneViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "1番目", style: .plain, target: nil, action: nil)
+
+        // backBarButton のタイトルを消す処理
+        // NOTE: iOS 14 では長押しでメニューが出るようになったので、 UI/UX 両立のために処理を切り分けている
+        if #available(iOS 14.0, *) {
+            navigationItem.backButtonDisplayMode = .minimal
+            // title = "1番目" も OK
+            navigationItem.backButtonTitle = "1番目"
+        } else {
+            // title = "" も OK
+            navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        }
     }
     
     static func makeInstance() -> ChildrenOneViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenThreeViewController.swift
@@ -12,7 +12,17 @@ class ChildrenThreeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "3番目", style: .plain, target: nil, action: nil)
+
+        // backBarButton のタイトルを消す処理
+        // NOTE: iOS 14 では長押しでメニューが出るようになったので、 UI/UX 両立のために処理を切り分けている
+        if #available(iOS 14.0, *) {
+            navigationItem.backButtonDisplayMode = .minimal
+            // title = "3番目" も OK
+            navigationItem.backButtonTitle = "3番目"
+        } else {
+            // title = "" も OK
+            navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        }
     }
 
     static func makeInstance() -> ChildrenThreeViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/Children/ChildrenTwoViewController.swift
@@ -12,7 +12,17 @@ class ChildrenTwoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "2番目", style: .plain, target: nil, action: nil)
+
+        // backBarButton のタイトルを消す処理
+        // NOTE: iOS 14 では長押しでメニューが出るようになったので、 UI/UX 両立のために処理を切り分けている
+        if #available(iOS 14.0, *) {
+            navigationItem.backButtonDisplayMode = .minimal
+            // title = "2番目" も OK
+            navigationItem.backButtonTitle = "2番目"
+        } else {
+            // title = "" も OK
+            navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        }
     }
     
     static func makeInstance() -> ChildrenTwoViewController {

--- a/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
+++ b/Towards14/Towards14/View/PushBackButtonLongPress/PushBackButtonLongPressViewController.swift
@@ -12,7 +12,17 @@ class PushBackButtonLongPressViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "0番目", style: .plain, target: nil, action: nil)
+
+        // backBarButton のタイトルを消す処理
+        // NOTE: iOS 14 では長押しでメニューが出るようになったので、 UI/UX 両立のために処理を切り分けている
+        if #available(iOS 14.0, *) {
+            navigationItem.backButtonDisplayMode = .minimal
+            // title = "0番目" も OK
+            navigationItem.backButtonTitle = "0番目"
+        } else {
+            // title = "" も OK
+            navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        }
     }
 
     static func makeInstance() -> PushBackButtonLongPressViewController {


### PR DESCRIPTION
## 問題
- UI の要求でバックボタンタイトルを消している
- 一方で、 iOS 14 から履歴メニューが追加され、 iOS 13 以下の方法では履歴メニュータイトルが空になり、 UX が低下する
- その対策としてバックボタンタイトルは付けて、 AppDelegate で透過処理を行っていた
- しかしこの方法では、全バックボタンタイトルが空になり、柔軟性がない

## 対策
- iOS 14 から追加された `navigationItem.backButtonDisplayMode` による制御に変更した
	- 当該プロパティは enum でバックボタンタイトルと履歴メニュータイトルの表示を制御できる
- `.minimal` にすることで、バックボタンタイトルは消して、履歴メニュータイトルはつけるということを実現した。

## スクリーンショット
- 見た目の変更がないため省略

## 参考文献
- [A new way to manage the back button title in iOS 14 with backButtonDisplayMode | Sarun](https://sarunw.com/posts/new-way-to-manage-back-button-title-in-ios14/)
- [iOS14で戻るボタンのタイトルを空欄にするきちんとした方法 | Spinners Inc.](https://spinners.work/posts/ios14_blank_back_button/)